### PR TITLE
(SIMP-4854) Update Minimum Puppet Version

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,5 +3,5 @@ fixtures:
   symlinks:
     # This is just needed for the test framework
     garbage: "#{source_dir}/spec/fixtures/stub_modules/garbage"
-    '../dist': "#{source_dir}"
+    '../dist': "#{source_dir}/dist"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ script:
 - bundle exec rake metadata_lint
 - bundle exec rake lint
 - bundle exec rake spec
+- bundle exec rake pkg:compare_latest_tag
+- bundle exec rake pkg:create_tag_changelog
 notifications:
   email: false
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,27 @@
-# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
-# ------------------------------------------------------------------------------
-#  release    pup   ruby      eol
-# PE 2016.4   4.7   2.1.9  TBD (LTS)
-# PE 2016.5   4.8   2.1.9  2017-10-31
-# SIMP6.0.0   4.8   2.1.9  TBD
-# PE 2017.1   4.9   2.1.9  2017-10-31
-# PE 2017.2   4.10  2.1.9  TBD
 ---
 language: ruby
-sudo: false
 cache: bundler
-before_script:
-- bundle update
-bundler_args: "--without development system_tests"
-before_install: rm Gemfile.lock || true
-script:
-- bundle exec rake metadata_lint
-- bundle exec rake lint
-- bundle exec rake spec
-- bundle exec rake pkg:compare_latest_tag
-- bundle exec rake pkg:create_tag_changelog
+sudo: false
+
+bundler_args: --without development system_tests --path .vendor
+
 notifications:
   email: false
-rvm:
-- 2.1.9
-env:
-  global:
-  - STRICT_VARIABLES=yes
-  matrix:
-  - PUPPET_VERSION="~> 4.8.2"
-  - PUPPET_VERSION="~> 4.10.0"
-  - PUPPET_VERSION="~> 4.9.2"
-  - PUPPET_VERSION="~> 4.7.0"
-matrix:
-  fast_finish: true
+
+addons:
+  apt:
+    packages:
+      - rpm
+
+before_install:
+  - rm -f Gemfile.lock
+
+jobs:
+  include:
+    - stage: check
+      rvm: 2.1.9
+      script:
+        - bundle exec rake metadata_lint
+        - bundle exec rake lint
+        - bundle exec rake pkg:compare_latest_tag
+        - bundle exec rake pkg:create_tag_changelog

--- a/build/simp-adapter.spec
+++ b/build/simp-adapter.spec
@@ -2,7 +2,7 @@
 
 Summary: SIMP Adapter for the AIO Puppet Installation
 Name: simp-adapter
-Version: 0.0.5
+Version: 0.0.6
 Release: 0%{?dist}
 License: Apache-2.0
 Group: Applications/System
@@ -19,7 +19,7 @@ Requires(post): puppetdb
 %{?el6:Requires(post): procps}
 %{?el7:Requires(post): procps-ng}
 Requires: puppet-agent < 2.0.0
-Requires: puppet-agent >= 1.6.2
+Requires: puppet-agent >= 1.10.4
 Requires: puppet-client-tools < 2.0.0
 Requires: puppet-client-tools >= 1.1.0
 Requires: puppetdb < 5.0.0
@@ -41,7 +41,7 @@ Requires(post): pe-puppetdb
 %{?el6:Requires(post): procps}
 %{?el7:Requires(post): procps-ng}
 Requires: puppet-agent < 2.0.0
-Requires: puppet-agent >= 1.6.2
+Requires: puppet-agent >= 1.10.4
 Requires: pe-client-tools >= 15.0.0
 Requires: pe-puppetdb < 5.0.0
 Requires: pe-puppetdb >= 4.2.2

--- a/build/simp-adapter.spec
+++ b/build/simp-adapter.spec
@@ -278,6 +278,12 @@ EOM
 )
 
 %changelog
+* Fri May 11 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.0.6-0
+- Updated the minimum version of the puppet-agent dependency to at least
+  1.10.4 (packages puppet 4.10.4), due to 'puppet generate types' bugs
+  in puppet-agent releases prior to that. These bugs cause the composite
+  namevar fixes to not function properly.
+
 * Fri Oct 20 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.0.5-0
 - Fixed the Changelog dates
 


### PR DESCRIPTION
The puppet version was updated to be at least 4.10.4 due to bugs in
releases prior to that which cause the composite namevar fixes for
`puppet generate types` to not function properly

SIMP-4854 #comment update simp-adapter