### PR TITLE
(SIMP-4011) 2nd attempt to fix deploy logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       script:
         - true
       before_deploy:
-        - "export SPECFILE_VERSION=`rpm -q --specfile build/*.spec --queryformat '%{VERSION}'`"
+        - "export SPECFILE_VERSION=`rpm -q --specfile build/*.spec --queryformat '%{VERSION}\n' | head -1`"
         - '[[ $TRAVIS_TAG =~ ^${SPECFILE_VERSION}$ ]]'
       deploy:
         - provider: releases


### PR DESCRIPTION
simp-adapter has 2 packages in its spec file.  The
original logic only worked for a single package.

SIMP-4011 #close