### PR TITLE
(SIMP-5225) SIMP6.3 puppet 5 updates

### DIFF
--- a/build/simp-adapter.spec
+++ b/build/simp-adapter.spec
@@ -41,13 +41,13 @@ Requires(post): pe-puppetdb
 %{?el6:Requires(post): procps}
 %{?el7:Requires(post): procps-ng}
 Requires: puppet-agent < 6.0.0
-Requires: puppet-agent >= 5.3.5
-Requires: pe-client-tools >= 15.0.0
+Requires: puppet-agent >= 5.5.6
+Requires: pe-client-tools >= 18.0.0
 Requires: pe-puppetdb < 6.0.0
 Requires: pe-puppetdb >= 5.2.4
 Requires: pe-puppetdb-termini < 6.0.0
-Requires: pe-puppetdb-termini >= 4.2.2
-Requires: pe-puppetserver >= 2015.0.0
+Requires: pe-puppetdb-termini >= 5.2.4
+Requires: pe-puppetserver >= 2018.1.0
 Provides: simp-adapter = %{version}
 Provides: simp-adapter-pe = %{version}
 

--- a/build/simp-adapter.spec
+++ b/build/simp-adapter.spec
@@ -2,7 +2,7 @@
 
 Summary: SIMP Adapter for the AIO Puppet Installation
 Name: simp-adapter
-Version: 0.0.6
+Version: 0.1.0
 Release: 0%{?dist}
 License: Apache-2.0
 Group: Applications/System
@@ -18,16 +18,16 @@ Requires(post): puppetserver
 Requires(post): puppetdb
 %{?el6:Requires(post): procps}
 %{?el7:Requires(post): procps-ng}
-Requires: puppet-agent < 2.0.0
-Requires: puppet-agent >= 1.10.4
+Requires: puppet-agent < 6.0.0
+Requires: puppet-agent >= 5.5.6
 Requires: puppet-client-tools < 2.0.0
-Requires: puppet-client-tools >= 1.1.0
-Requires: puppetdb < 5.0.0
-Requires: puppetdb >= 4.2.2
-Requires: puppetdb-termini < 5.0.0
-Requires: puppetdb-termini >= 4.2.2
-Requires: puppetserver < 3.0.0
-Requires: puppetserver >= 2.6.0
+Requires: puppet-client-tools >= 1.2.4
+Requires: puppetdb < 6.0.0
+Requires: puppetdb >= 5.2.4
+Requires: puppetdb-termini < 6.0.0
+Requires: puppetdb-termini >= 5.2.4
+Requires: puppetserver < 6.0.0
+Requires: puppetserver >= 5.3.5
 Provides: simp-adapter = %{version}
 Provides: simp-adapter-foss = %{version}
 
@@ -40,12 +40,12 @@ Requires(post): pe-puppetserver
 Requires(post): pe-puppetdb
 %{?el6:Requires(post): procps}
 %{?el7:Requires(post): procps-ng}
-Requires: puppet-agent < 2.0.0
-Requires: puppet-agent >= 1.10.4
+Requires: puppet-agent < 6.0.0
+Requires: puppet-agent >= 5.3.5
 Requires: pe-client-tools >= 15.0.0
-Requires: pe-puppetdb < 5.0.0
-Requires: pe-puppetdb >= 4.2.2
-Requires: pe-puppetdb-termini < 5.0.0
+Requires: pe-puppetdb < 6.0.0
+Requires: pe-puppetdb >= 5.2.4
+Requires: pe-puppetdb-termini < 6.0.0
 Requires: pe-puppetdb-termini >= 4.2.2
 Requires: pe-puppetserver >= 2015.0.0
 Provides: simp-adapter = %{version}
@@ -278,6 +278,9 @@ EOM
 )
 
 %changelog
+* Fri Sep 07 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 0.1.0-0
+- Updated to use puppet 5 for SIMP 6.3
+
 * Fri May 11 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.0.6-0
 - Updated the minimum version of the puppet-agent dependency to at least
   1.10.4 (packages puppet 4.10.4), due to 'puppet generate types' bugs


### PR DESCRIPTION
  - Updated the required versions for puppet packages to use Puppet 5
    for SIMP 6.3
SIMP-5225 #comment update simp-adapter